### PR TITLE
remove "use strict"

### DIFF
--- a/src/js/lib/Sample.js
+++ b/src/js/lib/Sample.js
@@ -1,5 +1,3 @@
-"use strict";
-
 export default class Sample {
     constructor (opts = {}) {
         this.name = opts.name;

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import Sample from "./lib/Sample";
 import $ from "jquery";
 


### PR DESCRIPTION
Babelifyが勝手につけるので不要です
